### PR TITLE
Add Content-Type: application/json header to response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v 0.1.5 (2015-12-21)
+* Add Content-Type: application/json header for response
+
 ### v 0.1.4 (2015-12-01)
 * Add prioritizeBy option
 

--- a/index.js
+++ b/index.js
@@ -140,6 +140,7 @@ function addRoute (reqToMock){
 						example || mock :
 						mock || example || '';
 
+				res.setHeader('content-type', 'application/json');
 				res.status(mockObj.defaultCode || 200).send(response);
 			} else {
 				res.status(404).send();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-mocker-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Node module to run server mocking API described in RAML files",
   "main": "index.js",
   "scripts": {

--- a/test/testApp.js
+++ b/test/testApp.js
@@ -16,6 +16,7 @@ function get (path){
 		res.setEncoding('utf8');
 		res.on('data', function (body) {
 			console.log('Got response: ' + res.statusCode);
+			console.log(res.headers['content-type']);
 			console.log(body);
 			dfd.resolve();
 		});


### PR DESCRIPTION
Currently the server always responds with `Content-Type: 'text/html'`. 

I changed it to `Content-Type: 'application/json'` since all responses are `JSON`s actually.

Probably it would be better to set proper mime-type depending on type of response. But not sure how it can be done.
